### PR TITLE
chore: disconnect Prisma client on exit

### DIFF
--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -2,6 +2,13 @@ import { PrismaClient } from "@prisma/client"
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient }
 
-export const prisma = globalForPrisma.prisma || new PrismaClient()
+// Use $extends for potential serverless optimisations
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient().$extends({})
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma
+
+// Gracefully disconnect Prisma when the process exits
+process.on("beforeExit", async () => {
+  await prisma.$disconnect()
+})


### PR DESCRIPTION
## Summary
- ensure Prisma Client disconnects when the process exits
- hint at serverless optimisations with `$extends`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e18cda64832c9a4ae94aeea0d5a1