### PR TITLE
Validate country slug or code inputs

### DIFF
--- a/src/app/members/[slugOrCode]/page.tsx
+++ b/src/app/members/[slugOrCode]/page.tsx
@@ -1,11 +1,12 @@
 // app/members/[slugOrCode]/page.tsx
 import { notFound } from "next/navigation";
 import { epunda } from "@/app/fonts";
-import { getCountry } from "@/utils/country";
+import { getCountry, normalizeSlugOrCode } from "@/utils/country";
 
 export async function generateMetadata({ params }: { params: Promise<{ slugOrCode: string }> }) {
     const awaitedParams = await params;
-    const country = await getCountry(awaitedParams.slugOrCode);
+    const slugOrCode = normalizeSlugOrCode(awaitedParams.slugOrCode);
+    const country = slugOrCode ? await getCountry(slugOrCode) : null;
     return {
         title: country ? `${country.name} • League` : "Country • League",
     };
@@ -13,7 +14,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slugOrCod
 
 export default async function PublicCountryPage({ params }: { params: Promise<{ slugOrCode: string }> }) {
     const awaitedParams = await params;
-    const country = await getCountry(awaitedParams.slugOrCode);
+    const slugOrCode = normalizeSlugOrCode(awaitedParams.slugOrCode);
+    if (!slugOrCode) notFound();
+    const country = await getCountry(slugOrCode);
     if (!country) notFound();
 
     return (

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,8 +1,23 @@
 import { prisma } from "@/prisma";
 
+/**
+ * Validate and normalize a country slug or code.
+ *
+ * Returns the matched value if it conforms to the whitelist regex or `null`
+ * otherwise. The regex limits input to 1–32 alphanumeric characters and
+ * hyphens to prevent accidental wide queries or injection attempts.
+ */
+export function normalizeSlugOrCode(value: string): string | null {
+    const match = value.match(/^[a-z0-9-]{1,32}$/i);
+    return match ? match[0] : null;
+}
+
 export async function getCountry(slugOrCode: string) {
-    const code = slugOrCode.toUpperCase();
-    const slug = slugOrCode.toLowerCase();
+    const normalized = normalizeSlugOrCode(slugOrCode);
+    if (!normalized) return null;
+
+    const code = normalized.toUpperCase();
+    const slug = normalized.toLowerCase();
 
     // Try by code, then by slug
     const byCode = await prisma.country.findFirst({


### PR DESCRIPTION
## Summary
- add normalizeSlugOrCode utility that whitelists `[a-z0-9-]{1,32}`
- guard getCountry and member page against invalid slugOrCode values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1dce680832c9d90b2e50f2baf53