### PR TITLE
Add CSRF protection to auth forms

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { auth, signIn, signOut } from "@/auth";
 import NavButton from "./NavButton";
+import { getCsrfToken } from "next-auth/react";
 
 const LogoPart = ({ size }: { size: number }) => {
   return (
@@ -19,14 +20,16 @@ const LogoPart = ({ size }: { size: number }) => {
   );
 };
 
-const FlagSignOutButton = ({ size, countryCode }: { size: number; countryCode: string }) => {
+const FlagSignOutButton = ({ size, countryCode, csrfToken }: { size: number; countryCode: string; csrfToken: string }) => {
   return (
     <form
+      method="post"
       action={async () => {
         "use server"
         await signOut()
       }}
     >
+      <input type="hidden" name="csrfToken" value={csrfToken} />
       <button
         type="submit"
       >
@@ -60,6 +63,7 @@ export default async function Header() {
   const session = await auth();
   const user = session?.user;
   const countryCode = user?.country?.code ?? "DEFAULT";
+  const csrfToken = await getCsrfToken();
 
   return (
     <header className="w-full sticky top-0 z-[999] bg-sky-200 border-b-4 border-red-700 shadow-md">
@@ -74,29 +78,33 @@ export default async function Header() {
             return true;
           }).map((link, i) => {
             const t = link.href === "/logout";
-            return t ?
-              <FlagSignOutButton key={i} size={3.5} countryCode={countryCode} /> :
+            return t ? (
+              <FlagSignOutButton key={i} size={3.5} countryCode={countryCode} csrfToken={csrfToken} />
+            ) : (
               <NavButton key={i} href={link.href} label={link.label} />
+            )
           })}
-          {!user && (
-            <form
-              action={async () => {
-                "use server"
-                await signIn("discord")
-              }}
-            >
-              <button
-                type="submit"
-                className={"px-6 py-2 rounded-sm text-white text-lg bg-[#6e2e2e] hover:bg-[#823a3a] tracking-wide uppercase transition-transform active:translate-y-0.5 focus:outline-none"}
-                style={{
-                  background: "linear-gradient(180deg, #0d5a86 0%, #0a4566 100%)",
-                  boxShadow: "0 3px 6px rgba(0,0,0,0.45)",
+            {!user && (
+              <form
+                method="post"
+                action={async () => {
+                  "use server"
+                  await signIn("discord")
                 }}
               >
-                Sign In
-              </button>
-            </form>
-          )}
+                <input type="hidden" name="csrfToken" value={csrfToken} />
+                <button
+                  type="submit"
+                  className={"px-6 py-2 rounded-sm text-white text-lg bg-[#6e2e2e] hover:bg-[#823a3a] tracking-wide uppercase transition-transform active:translate-y-0.5 focus:outline-none"}
+                  style={{
+                    background: "linear-gradient(180deg, #0d5a86 0%, #0a4566 100%)",
+                    boxShadow: "0 3px 6px rgba(0,0,0,0.45)",
+                  }}
+                >
+                  Sign In
+                </button>
+              </form>
+            )}
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- post sign-out form requests with CSRF token hidden input
- post sign-in form requests with CSRF token hidden input

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1a16c94832ca3489297274cd31c