### PR TITLE
Use next/image for member avatars

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.discordapp.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/members/[slugOrCode]/page.tsx
+++ b/src/app/members/[slugOrCode]/page.tsx
@@ -2,6 +2,7 @@
 import { notFound } from "next/navigation";
 import { epunda } from "@/app/fonts";
 import { getCountry } from "@/utils/country";
+import Image from "next/image";
 
 export async function generateMetadata({ params }: { params: Promise<{ slugOrCode: string }> }) {
     const awaitedParams = await params;
@@ -33,9 +34,17 @@ export default async function PublicCountryPage({ params }: { params: Promise<{ 
                             <li className="text-stone-400">No delegates registered.</li>
                         )}
                         {country.users.map(u => (
-                            <li key={u.id} className="flex items-center gap-3 rounded border border-stone-700 bg-stone-950/60 p-3">
-                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img src={u.image ?? "/logo.png"} alt="" className="h-8 w-8 rounded object-cover" />
+                            <li
+                                key={u.id}
+                                className="flex items-center gap-3 rounded border border-stone-700 bg-stone-950/60 p-3"
+                            >
+                                <Image
+                                    src={u.image ?? "/logo.png"}
+                                    alt={u.name ? `${u.name}'s avatar` : "Delegate avatar"}
+                                    className="h-8 w-8 rounded object-cover"
+                                    width={32}
+                                    height={32}
+                                />
                                 <span className="text-stone-200">{u.name ?? "Unnamed delegate"}</span>
                             </li>
                         ))}

--- a/src/app/members/me/page.tsx
+++ b/src/app/members/me/page.tsx
@@ -2,6 +2,7 @@
 import { redirect } from "next/navigation";
 import { epunda } from "@/app/fonts";
 import Link from "next/link";
+import Image from "next/image";
 import { auth } from "@/auth";
 import { getCountry } from "@/utils/country";
 
@@ -57,9 +58,17 @@ export default async function MyCountryPage() {
                             <li className="text-stone-400">No delegates yet.</li>
                         )}
                         {country.users.map(u => (
-                            <li key={u.id} className="flex items-center gap-3 rounded border border-stone-700 bg-stone-950/60 p-3">
-                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img src={u.image ?? "/logo.png"} alt="" className="h-8 w-8 rounded object-cover" />
+                            <li
+                                key={u.id}
+                                className="flex items-center gap-3 rounded border border-stone-700 bg-stone-950/60 p-3"
+                            >
+                                <Image
+                                    src={u.image ?? "/logo.png"}
+                                    alt={u.name ? `${u.name}'s avatar` : "Delegate avatar"}
+                                    className="h-8 w-8 rounded object-cover"
+                                    width={32}
+                                    height={32}
+                                />
                                 <span className="text-stone-200">{u.name ?? "Unnamed delegate"}</span>
                             </li>
                         ))}


### PR DESCRIPTION
## Summary
- switch member delegate avatars to Next.js `Image`
- allow Discord CDN images

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1bc2588832ca87ce52a840e8b12