### PR TITLE
feat: add absent vote option

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,6 +195,7 @@ enum VoteChoice {
   AYE
   NAY
   ABSTAIN
+  ABSENT
 }
 
 model Vote {

--- a/src/app/amendments/[slug]/page.tsx
+++ b/src/app/amendments/[slug]/page.tsx
@@ -8,12 +8,14 @@ import DiffPreview from "@/components/DiffPreview";
 
 export const dynamic = "force-dynamic";
 
-type Choice = "AYE" | "NAY" | "ABSTAIN";
+type Choice = "AYE" | "NAY" | "ABSTAIN" | "ABSENT";
 
 function choiceColor(choice?: Choice | null) {
     switch (choice) {
         case "AYE": return "bg-emerald-500";
         case "NAY": return "bg-rose-600";
+        case "ABSTAIN": return "bg-stone-500";
+        case "ABSENT": return "bg-stone-400";
         default: return "bg-stone-500";
     }
 }
@@ -192,7 +194,7 @@ const FlagsGrid = ({
     <section className="mx-auto mt-12 max-w-[95rem]">
         <div className="flex flex-wrap items-end justify-center gap-16">
             {countries.map((c) => {
-                const vote = byCountry.get(c.id) ?? null;
+                const vote = (byCountry.get(c.id) ?? "ABSENT") as Choice;
                 const flagSrc = `/flags/${(c.code || "unknown").toLowerCase()}.svg`;
                 return (
                     <div key={c.id} className="flex flex-col items-center">
@@ -200,7 +202,7 @@ const FlagsGrid = ({
                             <FlagImage src={flagSrc} alt={`${c.name} flag`} sizes="220px" className="object-cover" />
                         </div>
                         <div className="mt-6 h-[64px] w-[64px] rounded-[2px] border-[6px] border-stone-900 bg-white">
-                            {vote && <div className={`h-full w-full ${choiceColor(vote)}`} />}
+                            <div className={`h-full w-full ${choiceColor(vote)}`} />
                         </div>
                     </div>
                 );
@@ -240,6 +242,8 @@ const Meter = ({
     const aye = votes.filter(v => v.choice === "AYE").length;
     const nay = votes.filter(v => v.choice === "NAY").length;
     const abstain = votes.filter(v => v.choice === "ABSTAIN").length;
+    const absent = totalMembers - votes.length;
+    const abstainTotal = abstain + absent;
 
     const ayePct = pct(aye, totalMembers);
     const thresholdCount = Math.ceil((2 / 3) * totalMembers);
@@ -268,7 +272,7 @@ const Meter = ({
             </div>
             <div className="mt-2 flex items-center justify-between text-sm text-stone-300">
                 <span>
-                    Aye {aye} • Nay {nay} • Abstain {abstain}
+                    Aye {aye} • Nay {nay} • Abstain {abstainTotal}
                 </span>
                 <span>{thresholdCount} of {totalMembers} required</span>
             </div>

--- a/src/app/amendments/page.tsx
+++ b/src/app/amendments/page.tsx
@@ -40,9 +40,9 @@ export default async function AmendmentsPage() {
 
             <div className="mt-8 grid gap-4 md:grid-cols-2">
                 {items.map((a) => {
-                    const counts = { AYE: 0, NAY: 0, ABSTAIN: 0 } as Record<string, number>;
+                    const counts = { AYE: 0, NAY: 0, ABSTAIN: 0, ABSENT: 0 } as Record<string, number>;
                     a.votes.forEach((v) => counts[v.choice]++);
-                    const total = counts.AYE + counts.NAY + counts.ABSTAIN || 1;
+                    const total = counts.AYE + counts.NAY + counts.ABSTAIN + counts.ABSENT || 1;
                     const ayePct = Math.round((counts.AYE / total) * 100);
 
                     return (
@@ -71,7 +71,7 @@ export default async function AmendmentsPage() {
                                     />
                                 </div>
                                 <div className="mt-1 text-xs text-stone-400">
-                                    Nay: {counts.NAY} · Abstain: {counts.ABSTAIN}
+                                    Nay: {counts.NAY} · Abstain: {counts.ABSTAIN + counts.ABSENT}
                                 </div>
                             </div>
                         </Link>

--- a/src/components/Vote/VoteCard.tsx
+++ b/src/components/Vote/VoteCard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
-type Choice = "AYE" | "NAY" | "ABSTAIN";
+type Choice = "AYE" | "NAY" | "ABSTAIN" | "ABSENT";
 type Status = "OPEN" | "CLOSED" | string;
 
 export default function VoteCard({ slug, status }: { slug: string; status: Status }) {
@@ -31,7 +31,7 @@ export default function VoteCard({ slug, status }: { slug: string; status: Statu
     async function vote(next: Choice) {
         if (!canVote || pending) return;
         const prev = choice;
-        setChoice(next);
+        setChoice(next === "ABSENT" ? null : next);
 
         const res = await fetch(`/api/amendments/${encodeURIComponent(slug)}/vote`, {
             method: "POST",
@@ -52,7 +52,7 @@ export default function VoteCard({ slug, status }: { slug: string; status: Statu
     const Btn = ({
         label, value, bg, outline,
     }: { label: string; value: Choice; bg: string; outline: string }) => {
-        const active = choice === value;
+        const active = (choice ?? "ABSENT") === value;
         return (
             <button
                 type="button"
@@ -75,7 +75,7 @@ export default function VoteCard({ slug, status }: { slug: string; status: Statu
                     {canVote ? "Cast your vote" : "Voting closed"}
                 </div>
                 <div className="mt-1 text-sm text-stone-700">
-                    Your choice: <strong>{choice ?? "—"}</strong>
+                    Your choice: <strong>{choice ?? "ABSENT"}</strong>
                 </div>
             </div>
 
@@ -83,6 +83,7 @@ export default function VoteCard({ slug, status }: { slug: string; status: Statu
                 <Btn label="Yes" value="AYE" bg="bg-emerald-600" outline="border-stone-400" />
                 <Btn label="No" value="NAY" bg="bg-rose-600" outline="border-stone-400" />
                 <Btn label="Abstain" value="ABSTAIN" bg="bg-stone-500" outline="border-stone-400" />
+                <Btn label="Absent" value="ABSENT" bg="bg-stone-400" outline="border-stone-400" />
             </div>
         </div>
     );

--- a/src/utils/amendments.ts
+++ b/src/utils/amendments.ts
@@ -6,8 +6,8 @@ export async function finalizeAmendment(a: { id: string; threshold: number | nul
         where: { amendmentId: a.id },
         _count: true,
     });
-    const counts: Record<"AYE" | "NAY" | "ABSTAIN", number> = { AYE: 0, NAY: 0, ABSTAIN: 0 };
-    for (const v of votes) counts[v.choice as "AYE" | "NAY" | "ABSTAIN"] = v._count;
+    const counts: Record<"AYE" | "NAY" | "ABSTAIN" | "ABSENT", number> = { AYE: 0, NAY: 0, ABSTAIN: 0, ABSENT: 0 };
+    for (const v of votes) counts[v.choice as "AYE" | "NAY" | "ABSTAIN" | "ABSENT"] = v._count;
     const eligible = a.eligibleCount ?? (await prisma.country.count({ where: { isActive: true } }));
     const threshold = a.threshold ?? 2 / 3;
     const needed = Math.ceil(eligible * threshold);

--- a/src/utils/api/amendments.ts
+++ b/src/utils/api/amendments.ts
@@ -7,7 +7,7 @@ import { redirect } from "next/navigation";
 
 /* ---------------- types ---------------- */
 
-export type VoteChoice = "AYE" | "NAY" | "ABSTAIN";
+export type VoteChoice = "AYE" | "NAY" | "ABSTAIN" | "ABSENT";
 
 /* -------------- helpers --------------- */
 


### PR DESCRIPTION
## Summary
- add `ABSENT` option to vote enum and types
- allow users to mark themselves absent, removing their vote
- treat absent members as abstentions in tallies and UI

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68c72715c38c832ca4cc3a4b9fe6eaa4