### PR TITLE
refactor amendment page components

### DIFF
--- a/src/components/Amendment/StatusBanner.tsx
+++ b/src/components/Amendment/StatusBanner.tsx
@@ -1,0 +1,34 @@
+export default function StatusBanner({
+    status,
+    result,
+    closesAt,
+    failureReason,
+}: {
+    status: "OPEN" | "CLOSED" | string;
+    result: "PASSED" | "FAILED" | null | string;
+    closesAt: Date | null;
+    failureReason: string | null;
+}) {
+    if (status === "OPEN") {
+        return (
+            <span className="inline-flex items-center gap-2 rounded-full border border-blue-700/60 bg-blue-900/40 px-3 py-1 text-xs text-blue-200">
+                <span className="i" aria-hidden>●</span> Voting open
+                {closesAt && <span className="text-blue-300/80">• Closes {new Date(closesAt).toLocaleString()}</span>}
+            </span>
+        );
+    }
+
+    const passed = result === "PASSED";
+    const base =
+        "inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-semibold";
+    return passed ? (
+        <div className={`${base} border border-emerald-700 bg-emerald-900/40 text-emerald-200`}>
+            ✓ Passed{closesAt ? ` • ${new Date(closesAt).toLocaleString()}` : ""}
+        </div>
+    ) : (
+        <div className={`${base} flex-col items-start border border-rose-700 bg-rose-900/40 text-rose-200`}>
+            <div>✗ Failed{closesAt ? ` • ${new Date(closesAt).toLocaleString()}` : ""}</div>
+            {failureReason && <div className="mt-1 text-xs text-rose-300">{failureReason}</div>}
+        </div>
+    );
+}

--- a/src/components/Amendment/VoteMeter.tsx
+++ b/src/components/Amendment/VoteMeter.tsx
@@ -1,0 +1,98 @@
+import type { CSSProperties } from "react";
+
+type Choice = "AYE" | "NAY" | "ABSTAIN" | "ABSENT";
+
+export default function VoteMeter({
+    totalMembers,
+    votes,
+    closed,
+    result,
+}: {
+    totalMembers: number;
+    votes: { choice: Choice }[];
+    closed?: boolean;
+    result?: "PASSED" | "FAILED" | null | string;
+}) {
+    const aye = votes.filter(v => v.choice === "AYE").length;
+    const nay = votes.filter(v => v.choice === "NAY").length;
+    const abstain = votes.filter(v => v.choice === "ABSTAIN").length;
+    const absent = Math.max(0, totalMembers - votes.length);
+
+    const neutral = abstain + absent;
+
+    const pctFloat = (n: number, d: number) => (d ? Math.max(0, Math.min(100, (n / d) * 100)) : 0);
+
+    const ayePct = pctFloat(aye, totalMembers);
+    const nayPct = pctFloat(nay, totalMembers);
+    const neutralPct = pctFloat(neutral, totalMembers);
+
+    const thresholdCount = Math.ceil((2 / 3) * totalMembers);
+    const thresholdPct = Math.max(0, Math.min(100, (2 / 3) * 100));
+
+    const closedTint =
+        closed && result === "PASSED" ? "ring-2 ring-emerald-600"
+            : closed && result === "FAILED" ? "ring-2 ring-rose-600"
+                : "";
+
+    const neutralRight = nayPct;
+    const neutralStyle = nayPct > 0
+        ? { right: `${neutralRight}%`, width: `${neutralPct}%` }
+        : { right: `0%`, width: `${neutralPct}%` };
+
+    return (
+        <section className="mx-auto mt-8 max-w-4xl rounded">
+            <div className={`relative h-10 border-2 border-stone-900 bg-stone-100 shadow-[0_2px_0_rgba(0,0,0,1)] ${closedTint}`}>
+
+                {/* AYE (left → right) */}
+                {ayePct > 0 && (
+                    <div
+                        className="absolute inset-y-0 left-0 bg-emerald-600"
+                        style={{ width: `${ayePct}%` }}
+                        title={`Aye: ${aye}`}
+                    />
+                )}
+
+                {/* NEUTRAL (ABSTAIN + ABSENT) — to the left of NAY, or right-aligned if no NAY */}
+                {neutralPct > 0 && (
+                    <div
+                        className="absolute inset-y-0 bg-stone-500"
+                        style={neutralStyle as CSSProperties}
+                        title={`Neutral (Abstain + Absent): ${neutral}`}
+                    />
+                )}
+
+                {/* NAY (right → left) */}
+                {nayPct > 0 && (
+                    <div
+                        className="absolute inset-y-0 right-0 bg-rose-600"
+                        style={{ width: `${nayPct}%` }}
+                        title={`Nay: ${nay}`}
+                    />
+                )}
+
+                {/* Two-thirds threshold marker */}
+                <div
+                    className="absolute inset-y-0 w-[2px] bg-stone-900"
+                    style={{ left: `${thresholdPct}%` }}
+                    title="Two-thirds threshold"
+                />
+
+                {/* Lock overlay when closed */}
+                {closed && (
+                    <div className="absolute inset-0 grid place-items-center bg-stone-900/10 pointer-events-none">
+                        <span className="rounded-md border border-stone-700 bg-stone-900/80 px-2 py-0.5 text-xs text-stone-200">
+                            Voting closed
+                        </span>
+                    </div>
+                )}
+            </div>
+
+            <div className="mt-2 flex items-center justify-between text-sm text-stone-300">
+                <span>
+                    Aye {aye} • Nay {nay} • Abstain {abstain} • Absent {absent}
+                </span>
+                <span>{thresholdCount} of {totalMembers} required</span>
+            </div>
+        </section>
+    );
+}

--- a/src/components/Amendment/VoteSummary.tsx
+++ b/src/components/Amendment/VoteSummary.tsx
@@ -1,0 +1,74 @@
+import FlagImage from "@/components/FlagImage";
+
+type Choice = "AYE" | "NAY" | "ABSTAIN" | "ABSENT";
+
+function choiceColor(choice?: Choice | null) {
+    switch (choice) {
+        case "AYE": return "bg-emerald-600";
+        case "NAY": return "bg-rose-600";
+        case "ABSTAIN": return "bg-stone-500";
+        case "ABSENT": return "bg-stone-400";
+        default: return "bg-stone-500";
+    }
+}
+
+function LegendItem({ color, label }: { color: string; label: string }) {
+    return (
+        <span className="inline-flex items-center gap-2">
+            <span className={`inline-block h-3 w-6 rounded ${color}`} />
+            <span className="text-sm text-stone-300">{label}</span>
+        </span>
+    );
+}
+
+function Legend() {
+    return (
+        <div className="mt-8 flex flex-wrap items-center gap-4">
+            <LegendItem color="bg-emerald-600" label="Aye" />
+            <LegendItem color="bg-rose-600" label="Nay" />
+            <LegendItem color="bg-stone-500" label="Abstain / no vote" />
+        </div>
+    );
+}
+
+const FlagsGrid = ({
+    countries,
+    byCountry,
+}: {
+    countries: { name: string; id: string; slug: string; code: string | null }[];
+    byCountry: Map<string, Choice>;
+}) => (
+    <section className="mx-auto mt-12 max-w-[95rem]">
+        <div className="flex flex-wrap items-end justify-center gap-16">
+            {countries.map((c) => {
+                const vote = (byCountry.get(c.id) ?? "ABSENT") as Choice;
+                const flagSrc = `/flags/${(c.code || "unknown").toLowerCase()}.svg`;
+                return (
+                    <div key={c.id} className="flex flex-col items-center">
+                        <div className="relative h-[120px] w-[220px] overflow-hidden rounded-[2px] border-[6px] border-stone-900 bg-white">
+                            <FlagImage src={flagSrc} alt={`${c.name} flag`} sizes="220px" className="object-cover" />
+                        </div>
+                        <div className="mt-6 h-[64px] w-[64px] rounded-[2px] border-[6px] border-stone-900 bg-white">
+                            <div className={`h-full w-full ${choiceColor(vote)}`} />
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    </section>
+);
+
+export default function VoteSummary({
+    countries,
+    byCountry,
+}: {
+    countries: { name: string; id: string; slug: string; code: string | null }[];
+    byCountry: Map<string, Choice>;
+}) {
+    return (
+        <>
+            <Legend />
+            <FlagsGrid countries={countries} byCountry={byCountry} />
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- extract StatusBanner, VoteMeter, and VoteSummary components for amendment page
- simplify amendments/[slug] page imports and remove inline helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c73d1776f8832ca6688a8cb3a014e2