### PR TITLE
feat: schedule amendment closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Scheduled Amendment Closure
+
+Expired amendments are finalized by a scheduled job. The API route
+`/api/cron/close-expired-amendments` invokes the `closeExpiredAmendments`
+utility and is triggered every five minutes via a Vercel Cron job
+defined in `vercel.json`.

--- a/src/app/amendments/[slug]/page.tsx
+++ b/src/app/amendments/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import { prisma } from "@/prisma";
-import { closeExpiredAmendments } from "@/utils/amendments";
 import { epunda } from "@/app/fonts";
 import { notFound, redirect } from "next/navigation";
 import FlagImage from "@/components/FlagImage";
@@ -27,8 +26,6 @@ export default async function AmendmentPage({ params }: { params: Promise<{ slug
     const session = await auth();
     const user = session?.user;
     if (!session) redirect("/api/auth/signin?callbackUrl=/amendments/" + awaitedParams.slug);
-
-    await closeExpiredAmendments(awaitedParams.slug);
 
     const amendment = await prisma.amendment.findUnique({
         where: { slug: awaitedParams.slug },

--- a/src/app/amendments/page.tsx
+++ b/src/app/amendments/page.tsx
@@ -2,7 +2,6 @@
 import Link from "next/link";
 import { prisma } from "@/prisma";
 import { epunda } from "@/app/fonts";
-import { closeExpiredAmendments } from "@/utils/amendments";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { AmendmentResult, AmendmentStatus } from "@prisma/client";
@@ -34,8 +33,6 @@ const hasClosed = (closesAt: Date) => new Date() >= closesAt;
 export default async function AmendmentsPage() {
     const session = await auth();
     if (!session) redirect("/api/auth/signin?callbackUrl=/amendments");
-
-    await closeExpiredAmendments();
 
     const items = await prisma.amendment.findMany({
         orderBy: { createdAt: "desc" },

--- a/src/app/api/cron/close-expired-amendments/route.ts
+++ b/src/app/api/cron/close-expired-amendments/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { closeExpiredAmendments } from "@/utils/amendments";
+
+export async function GET() {
+    await closeExpiredAmendments();
+    return NextResponse.json({ ok: true });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/close-expired-amendments",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- remove `closeExpiredAmendments` calls from amendment pages
- add cron endpoint and Vercel schedule to finalize expired amendments
- document automated amendment closure in README

## Testing
- ⚠️ `npm test` *(missing script: test)*
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c73d7c13bc832cb56e7ddfb28c13fb