### PR TITLE
feat: add FAQ page and footer links

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { epunda } from "@/app/fonts";
+
+export const metadata = { title: "FAQ • League" };
+
+export default function FAQPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8 text-stone-100">
+      <header className="mb-8">
+        <h1 className={`${epunda.className} text-3xl font-extrabold`}>Frequently Asked Questions</h1>
+      </header>
+      <div className="space-y-8 text-stone-300">
+        <section>
+          <h2 className={`${epunda.className} text-xl font-semibold text-stone-100`}>Membership</h2>
+          <p className="mt-2">
+            Any sovereign state may apply for membership by submitting a formal request to the League Council.
+            Current members are listed on the{" "}
+            <Link href="/members" className="text-emerald-400 underline">members page</Link>.
+            Membership confers voting rights and responsibilities within the League.
+          </p>
+        </section>
+        <section>
+          <h2 className={`${epunda.className} text-xl font-semibold text-stone-100`}>Voting</h2>
+          <p className="mt-2">
+            Delegates cast votes on treaty articles and proposed amendments through this portal. Decisions require a
+            two-thirds majority to pass, meaning at least two-thirds of participating members must approve a measure for
+            it to be adopted.
+          </p>
+        </section>
+        <section>
+          <h2 className={`${epunda.className} text-xl font-semibold text-stone-100`}>Amendments</h2>
+          <p className="mt-2">
+            Any member state may propose an amendment to the treaty. Proposals are circulated for review and become
+            effective only after every member state ratifies the change. Browse current proposals on the{" "}
+            <Link href="/amendments" className="text-emerald-400 underline">amendments page</Link>.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,22 +1,25 @@
-import React from 'react'
+import React from "react";
+import Link from "next/link";
 
 const Footer = () => {
-    return (
-        <footer className="border-t border-stone-700 py-8 bg-stone-950">
-            <div className="mx-auto max-w-6xl px-4 text-sm text-stone-400">
-                {/* <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <p>
-                        © 1900 League Treaty Portal • Rendered in Next.js & TypeScript
-                    </p>
-                    <div className="flex items-center gap-4">
-                        <Link href="/about" className="hover:text-stone-200">About</Link>
-                        <Link href="/guides" className="hover:text-stone-200">Guides</Link>
-                        <Link href="/legal" className="hover:text-stone-200">Legal</Link>
-                    </div>
-                </div> */}
-            </div>
-        </footer>
-    )
-}
+  return (
+    <footer className="border-t border-stone-700 py-8 bg-stone-950">
+      <div className="mx-auto max-w-6xl px-4 text-sm text-stone-400">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p>© 1900 League Treaty Portal • Rendered in Next.js &amp; TypeScript</p>
+          <div className="flex items-center gap-4">
+            <Link href="/about" className="hover:text-stone-200">
+              About
+            </Link>
+            <Link href="/faq" className="hover:text-stone-200">
+              FAQ
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
 
-export default Footer
+export default Footer;
+


### PR DESCRIPTION
## Summary
- add FAQ page covering membership, voting and amendment processes with internal explanations
- link to the new FAQ from the footer and remove external references

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7446349c0832cb31bca69492a80d1