### PR TITLE
feat: add public API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Public API
+
+Versioned JSON endpoints are available under `/api/public/v1`.
+
+- `GET /api/public/v1/treaty` – return the current treaty text and articles.
+- `GET /api/public/v1/amendments` – list amendments with status and voting window.
+- `GET /api/public/v1/members` – list active member countries.
+
+All endpoints are rate limited to 60 requests per minute per IP.
+
 ## Getting Started
 
 First, run the development server:

--- a/src/app/api/public/v1/amendments/route.ts
+++ b/src/app/api/public/v1/amendments/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { rateLimit } from "@/utils/rateLimit";
+
+export async function GET(req: Request) {
+  const ip = req.headers.get("x-forwarded-for") ?? "anon";
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const amendments = await prisma.amendment.findMany({
+    orderBy: { createdAt: "desc" },
+    select: {
+      slug: true,
+      title: true,
+      status: true,
+      result: true,
+      opensAt: true,
+      closesAt: true,
+    },
+  });
+
+  return NextResponse.json({ amendments });
+}

--- a/src/app/api/public/v1/members/route.ts
+++ b/src/app/api/public/v1/members/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { rateLimit } from "@/utils/rateLimit";
+
+export async function GET(req: Request) {
+  const ip = req.headers.get("x-forwarded-for") ?? "anon";
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const members = await prisma.country.findMany({
+    where: { isActive: true },
+    orderBy: { name: "asc" },
+    select: {
+      name: true,
+      slug: true,
+      code: true,
+      colorHex: true,
+    },
+  });
+
+  return NextResponse.json({ members });
+}

--- a/src/app/api/public/v1/treaty/route.ts
+++ b/src/app/api/public/v1/treaty/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { rateLimit } from "@/utils/rateLimit";
+
+export async function GET(req: Request) {
+  const ip = req.headers.get("x-forwarded-for") ?? "anon";
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const treaty = await prisma.treaty.findUnique({
+    where: { slug: "league-treaty-1900" },
+    select: {
+      title: true,
+      slug: true,
+      preamble: true,
+      articles: {
+        orderBy: { order: "asc" },
+        select: { order: true, heading: true, body: true }
+      }
+    }
+  });
+
+  if (!treaty) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(treaty);
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,6 +14,12 @@ const Footer = () => {
             <Link href="/faq" className="hover:text-stone-200">
               FAQ
             </Link>
+            <Link
+              href="https://github.com/nrp-vote-website#public-api"
+              className="hover:text-stone-200"
+            >
+              API
+            </Link>
           </div>
         </div>
       </div>

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,0 +1,15 @@
+const hits = new Map<string, { count: number; reset: number }>();
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 60;
+
+export function rateLimit(ip: string, max = MAX_REQUESTS, windowMs = WINDOW_MS) {
+  const now = Date.now();
+  const entry = hits.get(ip);
+  if (!entry || now > entry.reset) {
+    hits.set(ip, { count: 1, reset: now + windowMs });
+    return true;
+  }
+  if (entry.count >= max) return false;
+  entry.count++;
+  return true;
+}


### PR DESCRIPTION
## Summary
- expose versioned public treaty, amendments, and members endpoints
- add simple in-memory rate limiting
- document public API and link from footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c74ad93108832cadad90374b928dc9