### PR TITLE
feat: notify delegates of pending votes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,9 @@ model User {
   countryId String?  @db.ObjectId
   country   Country? @relation(fields: [countryId], references: [id])
 
+  // Notification preferences
+  notificationSetting NotificationSetting?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -57,6 +60,17 @@ model CountryMapping {
   discordId String  @unique
   countryId String  @db.ObjectId
   country   Country @relation(fields: [countryId], references: [id])
+}
+
+model NotificationSetting {
+  id         String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId     String   @unique @db.ObjectId
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  inAppOnClose Boolean @default(true)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Account {


### PR DESCRIPTION
## Summary
- add `NotificationSetting` prisma model and user relation for in-app notification preferences
- schedule amendment watcher to log newly opened or closing votes
- surface banner in `Header` when a delegate's country has votes closing soon
- remove email notifications and nodemailer dependency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c74abe0498832c8f68216420feda24