### PR TITLE
Add page metadata with canonical and OG tags

### DIFF
--- a/src/app/amendments/[slug]/page.tsx
+++ b/src/app/amendments/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/prisma";
 import { closeExpiredAmendments } from "@/utils/amendments";
 import { epunda } from "@/app/fonts";
 import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
 import FlagImage from "@/components/FlagImage";
 import SlideOutVoteTab from "@/components/Vote/SlideOutVoteTab";
 import DiffPreview from "@/components/DiffPreview";
@@ -11,6 +12,43 @@ import VoteSummary from "@/components/Amendment/VoteSummary";
 import { auth } from "@/auth";
 
 export const dynamic = "force-dynamic";
+
+const baseUrl = "https://example.com";
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+    const { slug } = await params;
+    const amendment = await prisma.amendment.findUnique({
+        where: { slug },
+        select: { title: true, rationale: true },
+    });
+    const url = `${baseUrl}/amendments/${slug}`;
+    if (!amendment) {
+        return {
+            title: "Amendment • League",
+            description: "View details of a treaty amendment.",
+            keywords: ["amendment", "league"],
+            alternates: { canonical: url },
+            openGraph: {
+                title: "Amendment • League",
+                description: "View details of a treaty amendment.",
+                url,
+                images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+            },
+        };
+    }
+    return {
+        title: `${amendment.title} • League`,
+        description: amendment.rationale ?? "Details of a treaty amendment.",
+        keywords: ["amendment", "league", amendment.title],
+        alternates: { canonical: url },
+        openGraph: {
+            title: `${amendment.title} • League`,
+            description: amendment.rationale ?? "Details of a treaty amendment.",
+            url,
+            images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+        },
+    };
+}
 
 type Choice = "AYE" | "NAY" | "ABSTAIN" | "ABSENT";
 

--- a/src/app/amendments/new/page.tsx
+++ b/src/app/amendments/new/page.tsx
@@ -3,8 +3,24 @@ import { prisma } from "@/prisma";
 import { epunda } from "@/app/fonts";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
+import type { Metadata } from "next";
 import NewAmendmentComposer from "@/components/NewAmendmentComposer";
 import { createAmendmentAction } from "@/utils/api/amendments";
+
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+  title: "Propose Amendment • League",
+  description: "Draft and submit a new amendment to the League treaty.",
+  keywords: ["amendment", "proposal", "league"],
+  alternates: { canonical: `${baseUrl}/amendments/new` },
+  openGraph: {
+    title: "Propose Amendment • League",
+    description: "Draft and submit a new amendment to the League treaty.",
+    url: `${baseUrl}/amendments/new`,
+    images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+  },
+};
 
 export default async function NewAmendmentPage() {
   const session = await auth();

--- a/src/app/amendments/page.tsx
+++ b/src/app/amendments/page.tsx
@@ -3,9 +3,25 @@ import { prisma } from "@/prisma";
 import { closeExpiredAmendments } from "@/utils/amendments";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 import AmendmentsClient from "./AmendmentsClient";
 
 export const dynamic = "force-dynamic";
+
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+    title: "Amendments • League",
+    description: "Browse current and past amendments to the League treaty.",
+    keywords: ["amendments", "treaty", "league"],
+    alternates: { canonical: `${baseUrl}/amendments` },
+    openGraph: {
+        title: "Amendments • League",
+        description: "Browse current and past amendments to the League treaty.",
+        url: `${baseUrl}/amendments`,
+        images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+    },
+};
 
 export default async function AmendmentsPage() {
     const session = await auth();

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,7 +1,21 @@
 import Link from "next/link";
 import { epunda } from "@/app/fonts";
+import type { Metadata } from "next";
 
-export const metadata = { title: "FAQ • League" };
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+  title: "FAQ • League",
+  description: "Answers to common questions about the League of Free and Independent Nations.",
+  keywords: ["faq", "questions", "league"],
+  alternates: { canonical: `${baseUrl}/faq` },
+  openGraph: {
+    title: "FAQ • League",
+    description: "Answers to common questions about the League of Free and Independent Nations.",
+    url: `${baseUrl}/faq`,
+    images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+  },
+};
 
 export default function FAQPage() {
   return (

--- a/src/app/members/[slugOrCode]/page.tsx
+++ b/src/app/members/[slugOrCode]/page.tsx
@@ -3,12 +3,40 @@ import { notFound } from "next/navigation";
 import { epunda } from "@/app/fonts";
 import { getCountry } from "@/utils/country";
 import Image from "next/image";
+import type { Metadata } from "next";
 
-export async function generateMetadata({ params }: { params: Promise<{ slugOrCode: string }> }) {
+const baseUrl = "https://example.com";
+
+export async function generateMetadata({ params }: { params: Promise<{ slugOrCode: string }> }): Promise<Metadata> {
     const awaitedParams = await params;
     const country = await getCountry(awaitedParams.slugOrCode);
+    if (!country) {
+        const url = `${baseUrl}/members/${awaitedParams.slugOrCode}`;
+        return {
+            title: "Country • League",
+            description: "Public profile for a member country of the League.",
+            keywords: ["country", "league"],
+            alternates: { canonical: url },
+            openGraph: {
+                title: "Country • League",
+                description: "Public profile for a member country of the League.",
+                url,
+                images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+            },
+        };
+    }
+    const url = `${baseUrl}/members/${country.slug}`;
     return {
-        title: country ? `${country.name} • League` : "Country • League",
+        title: `${country.name} • League`,
+        description: `Public profile for ${country.name} in the League of Free and Independent Nations.`,
+        keywords: [country.name, "country", "league"],
+        alternates: { canonical: url },
+        openGraph: {
+            title: `${country.name} • League`,
+            description: `Public profile for ${country.name} in the League of Free and Independent Nations.`,
+            url,
+            images: [{ url: `${baseUrl}/flags/${(country.code || "unknown").toLowerCase()}.svg`, alt: `${country.name} flag` }],
+        },
     };
 }
 

--- a/src/app/members/me/page.tsx
+++ b/src/app/members/me/page.tsx
@@ -5,8 +5,22 @@ import Link from "next/link";
 import Image from "next/image";
 import { auth } from "@/auth";
 import { getCountry } from "@/utils/country";
+import type { Metadata } from "next";
 
-export const metadata = { title: "My Country • League" };
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+    title: "My Country • League",
+    description: "Private profile and tools for your country in the League.",
+    keywords: ["country", "profile", "league"],
+    alternates: { canonical: `${baseUrl}/members/me` },
+    openGraph: {
+        title: "My Country • League",
+        description: "Private profile and tools for your country in the League.",
+        url: `${baseUrl}/members/me`,
+        images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+    },
+};
 
 export default async function MyCountryPage() {
     const session = await auth();

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -3,8 +3,22 @@ import Link from "next/link";
 import { prisma } from "@/prisma";
 import { epunda } from "@/app/fonts";
 import { auth } from "@/auth";
+import type { Metadata } from "next";
 
-export const metadata = { title: "Countries • League" };
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+    title: "Countries • League",
+    description: "Browse member countries of the League of Free and Independent Nations.",
+    keywords: ["countries", "members", "league"],
+    alternates: { canonical: `${baseUrl}/members` },
+    openGraph: {
+        title: "Countries • League",
+        description: "Browse member countries of the League of Free and Independent Nations.",
+        url: `${baseUrl}/members`,
+        images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+    },
+};
 
 export default async function CountriesPage() {
     const session = await auth();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,26 @@
 
 // app/page.tsx — Home, 1900 Style with Epunda Sans
 import Link from "next/link";
+import type { Metadata } from "next";
 import { epunda } from "@/app/fonts";
 import { prisma } from "@/prisma";
 
 export const dynamic = "force-dynamic";
+
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+  title: "Home • League",
+  description: "Portal for the League of Free and Independent Nations.",
+  keywords: ["league", "treaty", "home"],
+  alternates: { canonical: `${baseUrl}/` },
+  openGraph: {
+    title: "Home • League",
+    description: "Portal for the League of Free and Independent Nations.",
+    url: `${baseUrl}/`,
+    images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+  },
+};
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (

--- a/src/app/treaty/page.tsx
+++ b/src/app/treaty/page.tsx
@@ -1,9 +1,25 @@
 import { prisma } from "@/prisma";
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import TreatyClient from "./TreatyClient";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
+
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+    title: "Treaty • League",
+    description: "Read the foundational treaty of the League of Free and Independent Nations.",
+    keywords: ["treaty", "league", "founding document"],
+    alternates: { canonical: `${baseUrl}/treaty` },
+    openGraph: {
+        title: "Treaty • League",
+        description: "Read the foundational treaty of the League of Free and Independent Nations.",
+        url: `${baseUrl}/treaty`,
+        images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+    },
+};
 
 export default async function TreatyPage() {
     const treaty = await prisma.treaty.findUnique({

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,6 +1,20 @@
 import { epunda } from "@/app/fonts";
+import type { Metadata } from "next";
 
-export const metadata = { title: "Our Work • League" };
+const baseUrl = "https://example.com";
+
+export const metadata: Metadata = {
+  title: "Our Work • League",
+  description: "Discover initiatives undertaken by the League of Free and Independent Nations.",
+  keywords: ["work", "initiatives", "league"],
+  alternates: { canonical: `${baseUrl}/work` },
+  openGraph: {
+    title: "Our Work • League",
+    description: "Discover initiatives undertaken by the League of Free and Independent Nations.",
+    url: `${baseUrl}/work`,
+    images: [{ url: `${baseUrl}/logo.png`, alt: "League logo" }],
+  },
+};
 
 export default function WorkPage() {
   return (


### PR DESCRIPTION
## Summary
- add metadata/generateMetadata to pages with canonical URLs, keywords and Open Graph images
- ensure country pages use flag images for OG tags

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `DATABASE_URL="mongodb://localhost:27017/test" npm run build` *(fails: Server selection timeout for MongoDB)*
- `curl -s http://localhost:3000/work | grep -o '<meta[^>]*>' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c74ab0152c832c90b3ae9354d50b59