### PR TITLE
Add WebSocket presence tracking endpoint and client helper

### DIFF
--- a/src/app/api/socket/route.ts
+++ b/src/app/api/socket/route.ts
@@ -1,0 +1,212 @@
+import { NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+type PresenceEvent = {
+  event: string;
+  payload?: unknown;
+};
+
+type PresenceHeartbeatPayload = {
+  countryId: string;
+};
+
+type ServerWebSocket = WebSocket & {
+  accept?: () => void;
+};
+
+type PresenceConnection = {
+  socket: ServerWebSocket;
+  countryId: string | null;
+  lastHeartbeat: number;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+};
+
+type PresenceRoomState = Map<string, PresenceConnection>;
+
+type PresenceRoomsStore = Map<string, PresenceRoomState>;
+
+const HEARTBEAT_INTERVAL_MS = 5_000;
+const HEARTBEAT_TIMEOUT_MS = 15_000;
+const DEFAULT_ROOM_ID = 'presence';
+
+const globalPresence = globalThis as typeof globalThis & {
+  __presenceRoomsStore?: PresenceRoomsStore;
+};
+
+const rooms: PresenceRoomsStore =
+  globalPresence.__presenceRoomsStore ?? (globalPresence.__presenceRoomsStore = new Map());
+
+export function GET(request: NextRequest) {
+  if (request.headers.get('upgrade') !== 'websocket') {
+    return new Response('Expected WebSocket upgrade.', { status: 426 });
+  }
+
+  const roomId = request.nextUrl.searchParams.get('room') ?? DEFAULT_ROOM_ID;
+  const pair = new WebSocketPair();
+  const [client, server] = Object.values(pair) as [ServerWebSocket, ServerWebSocket];
+
+  server.accept?.();
+  registerConnection(roomId, server);
+
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+  } as ResponseInit & { webSocket: ServerWebSocket });
+}
+
+function registerConnection(roomId: string, socket: ServerWebSocket) {
+  const connectionId = crypto.randomUUID();
+  const room = getOrCreateRoom(roomId);
+
+  const connection: PresenceConnection = {
+    socket,
+    countryId: null,
+    lastHeartbeat: Date.now(),
+    heartbeatTimer: null,
+  };
+
+  room.set(connectionId, connection);
+
+  const heartbeatTimer = setInterval(() => {
+    if (Date.now() - connection.lastHeartbeat > HEARTBEAT_TIMEOUT_MS) {
+      safeClose(socket, 4000, 'Heartbeat timeout');
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
+  connection.heartbeatTimer = heartbeatTimer;
+
+  socket.addEventListener('message', (event) => {
+    if (typeof event.data !== 'string') {
+      return;
+    }
+
+    const message = safeParseMessage(event.data);
+    if (!message) {
+      return;
+    }
+
+    if (message.event === 'presence:heartbeat') {
+      handleHeartbeat(roomId, connectionId, connection, message.payload);
+    }
+  });
+
+  let cleanedUp = false;
+
+  const cleanup = () => {
+    if (cleanedUp) {
+      return;
+    }
+
+    cleanedUp = true;
+    clearIntervalIfNeeded(connection.heartbeatTimer);
+    connection.heartbeatTimer = null;
+    const roomState = rooms.get(roomId);
+    if (!roomState) {
+      return;
+    }
+
+    roomState.delete(connectionId);
+    if (roomState.size === 0) {
+      rooms.delete(roomId);
+    }
+
+    broadcastPresence(roomId);
+  };
+
+  socket.addEventListener('close', cleanup);
+  socket.addEventListener('error', cleanup);
+}
+
+function handleHeartbeat(
+  roomId: string,
+  connectionId: string,
+  connection: PresenceConnection,
+  payload: unknown,
+) {
+  if (!payload || typeof payload !== 'object' || !('countryId' in payload)) {
+    return;
+  }
+
+  const { countryId } = payload as PresenceHeartbeatPayload;
+  if (typeof countryId !== 'string' || countryId.length === 0) {
+    return;
+  }
+
+  connection.countryId = countryId;
+  connection.lastHeartbeat = Date.now();
+
+  const room = rooms.get(roomId);
+  if (!room || !room.has(connectionId)) {
+    return;
+  }
+
+  broadcastPresence(roomId);
+}
+
+function broadcastPresence(roomId: string) {
+  const room = rooms.get(roomId);
+  if (!room) {
+    return;
+  }
+
+  const countryIds = Array.from(
+    new Set(
+      Array.from(room.values())
+        .map((connection) => connection.countryId)
+        .filter((countryId): countryId is string => typeof countryId === 'string' && countryId.length > 0),
+    ),
+  );
+
+  const payload = JSON.stringify({
+    event: 'presence:update',
+    payload: {
+      countryIds,
+    },
+  });
+
+  for (const connection of room.values()) {
+    safeSend(connection.socket, payload);
+  }
+}
+
+function getOrCreateRoom(roomId: string): PresenceRoomState {
+  let room = rooms.get(roomId);
+  if (!room) {
+    room = new Map();
+    rooms.set(roomId, room);
+  }
+
+  return room;
+}
+
+function safeSend(socket: ServerWebSocket, data: string) {
+  try {
+    socket.send(data);
+  } catch (error) {
+    console.error('Failed to send WebSocket message.', error);
+  }
+}
+
+function safeClose(socket: ServerWebSocket, code: number, reason: string) {
+  try {
+    socket.close(code, reason);
+  } catch (error) {
+    console.error('Failed to close WebSocket connection.', error);
+  }
+}
+
+function clearIntervalIfNeeded(timer: PresenceConnection['heartbeatTimer']) {
+  if (timer != null) {
+    clearInterval(timer);
+  }
+}
+
+function safeParseMessage(raw: string): PresenceEvent | null {
+  try {
+    return JSON.parse(raw) as PresenceEvent;
+  } catch (error) {
+    console.warn('Received invalid WebSocket payload.', error);
+    return null;
+  }
+}

--- a/src/app/api/socket/route.ts
+++ b/src/app/api/socket/route.ts
@@ -44,7 +44,8 @@ export function GET(request: NextRequest) {
 
   const roomId = request.nextUrl.searchParams.get('room') ?? DEFAULT_ROOM_ID;
   const pair = new WebSocketPair();
-  const [client, server] = Object.values(pair) as [ServerWebSocket, ServerWebSocket];
+  const client = pair[0] as ServerWebSocket;
+  const server = pair[1] as ServerWebSocket;
 
   server.accept?.();
   registerConnection(roomId, server);

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -36,7 +36,7 @@ export function connectToPresenceSocket(
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
 
   const socket = new WebSocket(url);
-  let heartbeatTimer: ReturnType<typeof window.setInterval> | undefined;
+  let heartbeatTimer: number | null = null;
 
   const sendHeartbeat = () => {
     if (socket.readyState !== WebSocket.OPEN) {
@@ -83,18 +83,18 @@ export function connectToPresenceSocket(
   });
 
   socket.addEventListener('close', (event) => {
-    if (heartbeatTimer) {
+    if (heartbeatTimer !== null) {
       window.clearInterval(heartbeatTimer);
-      heartbeatTimer = undefined;
+      heartbeatTimer = null;
     }
 
     options.onClose?.(event);
   });
 
   const disconnect = () => {
-    if (heartbeatTimer) {
+    if (heartbeatTimer !== null) {
       window.clearInterval(heartbeatTimer);
-      heartbeatTimer = undefined;
+      heartbeatTimer = null;
     }
 
     if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -1,0 +1,120 @@
+export const DEFAULT_PRESENCE_ROOM = 'presence';
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_500;
+
+export type PresenceUpdateHandler = (countryIds: string[]) => void;
+
+export interface PresenceClientOptions {
+  countryId: string;
+  roomId?: string;
+  heartbeatIntervalMs?: number;
+  onOpen?: (socket: WebSocket) => void;
+  onUpdate?: PresenceUpdateHandler;
+  onError?: (event: Event) => void;
+  onClose?: (event: CloseEvent) => void;
+}
+
+export interface PresenceClientConnection {
+  socket: WebSocket;
+  sendHeartbeat: () => void;
+  updateCountry: (countryId: string) => void;
+  disconnect: () => void;
+}
+
+export function connectToPresenceSocket(
+  options: PresenceClientOptions,
+): PresenceClientConnection | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const roomId = options.roomId ?? DEFAULT_PRESENCE_ROOM;
+  const heartbeatInterval = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  let currentCountryId = options.countryId;
+
+  const url = new URL('/api/socket', window.location.origin);
+  url.searchParams.set('room', roomId);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+
+  const socket = new WebSocket(url);
+  let heartbeatTimer: ReturnType<typeof window.setInterval> | undefined;
+
+  const sendHeartbeat = () => {
+    if (socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    socket.send(
+      JSON.stringify({
+        event: 'presence:heartbeat',
+        payload: {
+          countryId: currentCountryId,
+        },
+      }),
+    );
+  };
+
+  socket.addEventListener('open', () => {
+    sendHeartbeat();
+    heartbeatTimer = window.setInterval(sendHeartbeat, heartbeatInterval);
+    options.onOpen?.(socket);
+  });
+
+  socket.addEventListener('message', (event) => {
+    if (typeof event.data !== 'string') {
+      return;
+    }
+
+    try {
+      const message = JSON.parse(event.data) as {
+        event?: string;
+        payload?: { countryIds?: unknown };
+      };
+
+      if (message.event === 'presence:update' && Array.isArray(message.payload?.countryIds)) {
+        options.onUpdate?.(message.payload.countryIds.filter(isString));
+      }
+    } catch (error) {
+      console.warn('Failed to parse presence update payload.', error);
+    }
+  });
+
+  socket.addEventListener('error', (event) => {
+    options.onError?.(event);
+  });
+
+  socket.addEventListener('close', (event) => {
+    if (heartbeatTimer) {
+      window.clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+
+    options.onClose?.(event);
+  });
+
+  const disconnect = () => {
+    if (heartbeatTimer) {
+      window.clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+
+    if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+      socket.close();
+    }
+  };
+
+  const updateCountry = (countryId: string) => {
+    currentCountryId = countryId;
+    sendHeartbeat();
+  };
+
+  return {
+    socket,
+    sendHeartbeat,
+    updateCountry,
+    disconnect,
+  };
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}

--- a/types/edge-runtime.d.ts
+++ b/types/edge-runtime.d.ts
@@ -1,0 +1,13 @@
+export {};
+
+declare global {
+  interface EdgeWebSocketPair {
+    0: WebSocket;
+    1: WebSocket;
+  }
+
+  const WebSocketPair: {
+    prototype: EdgeWebSocketPair;
+    new (): EdgeWebSocketPair;
+  };
+}


### PR DESCRIPTION
## Summary
- add an Edge runtime WebSocket route that manages presence rooms and broadcasts updates to subscribers
- process heartbeat messages to keep country presence lists up to date and prune inactive connections
- provide a client-side utility for establishing the presence socket and sending heartbeats from the browser

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c83ce17d10832cb3e2f7585461ddaa