### PR TITLE
Add discussion, motion, and chair API handlers

### DIFF
--- a/src/app/api/amendments/[slug]/discussions/route.ts
+++ b/src/app/api/amendments/[slug]/discussions/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+
+export async function POST(
+    _req: Request,
+    { params }: { params: Promise<{ slug: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { session, country } = await requireAuthContext();
+
+        const amendment = await prisma.amendment.findUnique({
+            where: { slug: awaitedParams.slug },
+            select: { id: true, title: true },
+        });
+
+        if (!amendment) {
+            throw new ApiError(404, "Amendment not found");
+        }
+
+        const threadSlug = `amendment-${awaitedParams.slug}-discussion`;
+        let thread = await prisma.discussionThread.findUnique({ where: { slug: threadSlug } });
+
+        if (!thread) {
+            thread = await prisma.discussionThread.create({
+                data: {
+                    slug: threadSlug,
+                    title: `Discussion: ${amendment.title}`,
+                    summary: `Discussion thread for amendment ${awaitedParams.slug}`,
+                    createdByCountryId: country.id,
+                    createdByUserId: session.user?.id ?? null,
+                },
+            });
+
+            return NextResponse.json({ thread, created: true }, { status: 201 });
+        }
+
+        return NextResponse.json({ thread, created: false });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to bootstrap amendment discussion thread", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/chair/emergency/route.ts
+++ b/src/app/api/chair/emergency/route.ts
@@ -1,0 +1,177 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const emergencySchema = z.discriminatedUnion("action", [
+    z.object({
+        action: z.literal("LOCK_THREAD"),
+        threadId: z.string(),
+        note: z.string().optional(),
+    }),
+    z.object({
+        action: z.literal("UNLOCK_THREAD"),
+        threadId: z.string(),
+        note: z.string().optional(),
+    }),
+    z.object({
+        action: z.literal("PIN_THREAD"),
+        threadId: z.string(),
+        note: z.string().optional(),
+    }),
+    z.object({
+        action: z.literal("UNPIN_THREAD"),
+        threadId: z.string(),
+        note: z.string().optional(),
+    }),
+    z.object({
+        action: z.literal("ARCHIVE_THREAD"),
+        threadId: z.string(),
+        archived: z.boolean().optional(),
+        note: z.string().optional(),
+    }),
+    z.object({
+        action: z.literal("RESTORE_POST"),
+        postId: z.string(),
+        note: z.string().optional(),
+    }),
+]);
+
+type EmergencyRequest = z.infer<typeof emergencySchema>;
+
+async function ensureThread(threadId: string) {
+    const thread = await prisma.discussionThread.findUnique({
+        where: { id: threadId },
+        select: { id: true },
+    });
+
+    if (!thread) {
+        throw new ApiError(404, "Thread not found");
+    }
+
+    return thread;
+}
+
+export async function POST(req: Request) {
+    try {
+        const { userId, country } = await requireAuthContext({ requireChair: true });
+        const parsed = emergencySchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const payload: EmergencyRequest = parsed.data;
+        const now = new Date();
+
+        if (payload.action === "RESTORE_POST") {
+            const post = await prisma.discussionPost.findUnique({
+                where: { id: payload.postId },
+                select: { id: true, isDeleted: true },
+            });
+
+            if (!post) {
+                throw new ApiError(404, "Post not found");
+            }
+
+            const restoredPost = await prisma.discussionPost.update({
+                where: { id: post.id },
+                data: { isDeleted: false, deletedAt: null },
+                select: {
+                    id: true,
+                    threadId: true,
+                    isDeleted: true,
+                    deletedAt: true,
+                },
+            });
+
+            await prisma.chairActionLog.create({
+                data: {
+                    type: "RESTORE_POST",
+                    actorCountryId: country.id,
+                    actorUserId: userId ?? null,
+                    postId: restoredPost.id,
+                    threadId: restoredPost.threadId,
+                    note: payload.note ?? null,
+                    metadata: {
+                        action: payload.action,
+                    },
+                },
+            });
+
+            return NextResponse.json({ post: restoredPost });
+        }
+
+        const thread = await ensureThread(payload.threadId);
+        let updatedThread;
+        let type: "LOCK_THREAD" | "UNLOCK_THREAD" | "PIN_THREAD" | "UNPIN_THREAD" | "ARCHIVE_THREAD";
+        let metadata: Record<string, unknown> | undefined;
+
+        switch (payload.action) {
+            case "LOCK_THREAD":
+                updatedThread = await prisma.discussionThread.update({
+                    where: { id: thread.id },
+                    data: { isLocked: true },
+                });
+                type = "LOCK_THREAD";
+                break;
+            case "UNLOCK_THREAD":
+                updatedThread = await prisma.discussionThread.update({
+                    where: { id: thread.id },
+                    data: { isLocked: false },
+                });
+                type = "UNLOCK_THREAD";
+                break;
+            case "PIN_THREAD":
+                updatedThread = await prisma.discussionThread.update({
+                    where: { id: thread.id },
+                    data: { isPinned: true },
+                });
+                type = "PIN_THREAD";
+                break;
+            case "UNPIN_THREAD":
+                updatedThread = await prisma.discussionThread.update({
+                    where: { id: thread.id },
+                    data: { isPinned: false },
+                });
+                type = "UNPIN_THREAD";
+                break;
+            case "ARCHIVE_THREAD": {
+                const archived = payload.archived ?? true;
+                updatedThread = await prisma.discussionThread.update({
+                    where: { id: thread.id },
+                    data: { isArchived: archived },
+                });
+                type = "ARCHIVE_THREAD";
+                metadata = { archived };
+                break;
+            }
+            default:
+                throw new ApiError(400, "Unsupported action");
+        }
+
+        await prisma.chairActionLog.create({
+            data: {
+                type,
+                actorCountryId: country.id,
+                actorUserId: userId ?? null,
+                threadId: updatedThread.id,
+                note: payload.note ?? null,
+                metadata: {
+                    action: payload.action,
+                    ...(metadata ?? {}),
+                    timestamp: now.toISOString(),
+                },
+            },
+        });
+
+        return NextResponse.json({ thread: updatedThread });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to process emergency chair action", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/chair/rule/route.ts
+++ b/src/app/api/chair/rule/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const ruleSchema = z.object({
+    motionId: z.string(),
+    outcome: z.enum(["PASSED", "FAILED", "EXECUTED"]),
+    note: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+    try {
+        const { userId, country } = await requireAuthContext({ requireChair: true });
+        const parsed = ruleSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const motion = await prisma.modMotion.findUnique({
+            where: { id: parsed.data.motionId },
+            select: { id: true },
+        });
+
+        if (!motion) {
+            throw new ApiError(404, "Motion not found");
+        }
+
+        const now = new Date();
+
+        const updatedMotion = await prisma.$transaction(async (tx) => {
+            const updated = await tx.modMotion.update({
+                where: { id: motion.id },
+                data: {
+                    status: parsed.data.outcome,
+                    closedAt: now,
+                    resolvedAt: now,
+                    resolutionNote: parsed.data.note ?? null,
+                },
+            });
+
+            await tx.chairActionLog.create({
+                data: {
+                    type: "LOG_NOTE",
+                    actorCountryId: country.id,
+                    actorUserId: userId ?? null,
+                    motionId: updated.id,
+                    note: parsed.data.note ?? `${parsed.data.outcome} ruling issued`,
+                    metadata: {
+                        outcome: parsed.data.outcome,
+                    },
+                },
+            });
+
+            return updated;
+        });
+
+        return NextResponse.json({ motion: updatedMotion });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to record chair ruling", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/discussions/[threadId]/posts/[postId]/route.ts
+++ b/src/app/api/discussions/[threadId]/posts/[postId]/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const updatePostSchema = z.object({
+    body: z.string().min(1, "Body is required"),
+});
+
+export async function GET(
+    _req: Request,
+    { params }: { params: Promise<{ threadId: string; postId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        await requireAuthContext();
+
+        const post = await prisma.discussionPost.findFirst({
+            where: { id: awaitedParams.postId, threadId: awaitedParams.threadId },
+            select: {
+                id: true,
+                body: true,
+                parentPostId: true,
+                isEdited: true,
+                isDeleted: true,
+                deletedAt: true,
+                editedAt: true,
+                createdAt: true,
+                updatedAt: true,
+                authorUser: { select: { id: true, name: true, image: true } },
+                authorCountry: {
+                    select: { id: true, name: true, slug: true, code: true, colorHex: true },
+                },
+            },
+        });
+
+        if (!post) {
+            throw new ApiError(404, "Post not found");
+        }
+
+        return NextResponse.json({ post });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to load discussion post", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}
+
+export async function PATCH(
+    req: Request,
+    { params }: { params: Promise<{ threadId: string; postId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { country } = await requireAuthContext();
+        const parsed = updatePostSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const post = await prisma.discussionPost.findFirst({
+            where: { id: awaitedParams.postId, threadId: awaitedParams.threadId },
+            select: { id: true, authorCountryId: true, thread: { select: { isLocked: true, isArchived: true } } },
+        });
+
+        if (!post) {
+            throw new ApiError(404, "Post not found");
+        }
+
+        if (post.thread.isLocked || post.thread.isArchived) {
+            throw new ApiError(403, "Thread is not accepting updates");
+        }
+
+        if (post.authorCountryId !== country.id) {
+            throw new ApiError(403, "Cannot edit another country's post");
+        }
+
+        const updated = await prisma.discussionPost.update({
+            where: { id: post.id },
+            data: {
+                body: parsed.data.body,
+                isEdited: true,
+                editedAt: new Date(),
+            },
+            select: {
+                id: true,
+                body: true,
+                parentPostId: true,
+                isEdited: true,
+                isDeleted: true,
+                deletedAt: true,
+                editedAt: true,
+                createdAt: true,
+                updatedAt: true,
+                authorUser: { select: { id: true, name: true, image: true } },
+                authorCountry: {
+                    select: { id: true, name: true, slug: true, code: true, colorHex: true },
+                },
+            },
+        });
+
+        return NextResponse.json({ post: updated });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to update discussion post", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    _req: Request,
+    { params }: { params: Promise<{ threadId: string; postId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { country } = await requireAuthContext();
+
+        const post = await prisma.discussionPost.findFirst({
+            where: { id: awaitedParams.postId, threadId: awaitedParams.threadId },
+            select: { id: true, isDeleted: true, authorCountryId: true },
+        });
+
+        if (!post) {
+            throw new ApiError(404, "Post not found");
+        }
+
+        if (post.authorCountryId !== country.id) {
+            throw new ApiError(403, "Cannot delete another country's post");
+        }
+
+        if (post.isDeleted) {
+            throw new ApiError(409, "Post already deleted");
+        }
+
+        await prisma.discussionPost.update({
+            where: { id: post.id },
+            data: { isDeleted: true, deletedAt: new Date() },
+        });
+
+        return NextResponse.json({ ok: true });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to delete discussion post", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/discussions/[threadId]/posts/route.ts
+++ b/src/app/api/discussions/[threadId]/posts/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const createPostSchema = z.object({
+    body: z.string().min(1, "Body is required"),
+    parentPostId: z.string().optional(),
+});
+
+export async function GET(
+    _req: Request,
+    { params }: { params: Promise<{ threadId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        await requireAuthContext();
+
+        const thread = await prisma.discussionThread.findUnique({
+            where: { id: awaitedParams.threadId },
+            select: { id: true },
+        });
+
+        if (!thread) {
+            throw new ApiError(404, "Thread not found");
+        }
+
+        const posts = await prisma.discussionPost.findMany({
+            where: { threadId: thread.id },
+            orderBy: { createdAt: "asc" },
+            select: {
+                id: true,
+                body: true,
+                parentPostId: true,
+                isEdited: true,
+                isDeleted: true,
+                deletedAt: true,
+                editedAt: true,
+                createdAt: true,
+                updatedAt: true,
+                authorUser: { select: { id: true, name: true, image: true } },
+                authorCountry: {
+                    select: { id: true, name: true, slug: true, code: true, colorHex: true },
+                },
+            },
+        });
+
+        return NextResponse.json({ posts });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to load discussion posts", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}
+
+export async function POST(
+    req: Request,
+    { params }: { params: Promise<{ threadId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { userId, country } = await requireAuthContext();
+        const parsed = createPostSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const thread = await prisma.discussionThread.findUnique({
+            where: { id: awaitedParams.threadId },
+            select: { id: true, isLocked: true, isArchived: true },
+        });
+
+        if (!thread) {
+            throw new ApiError(404, "Thread not found");
+        }
+
+        if (thread.isLocked || thread.isArchived) {
+            throw new ApiError(403, "Thread is not accepting new posts");
+        }
+
+        if (parsed.data.parentPostId) {
+            const parentPost = await prisma.discussionPost.findUnique({
+                where: { id: parsed.data.parentPostId },
+                select: { threadId: true },
+            });
+
+            if (!parentPost || parentPost.threadId !== thread.id) {
+                throw new ApiError(400, "Parent post must belong to the same thread");
+            }
+        }
+
+        const post = await prisma.discussionPost.create({
+            data: {
+                threadId: thread.id,
+                body: parsed.data.body,
+                parentPostId: parsed.data.parentPostId ?? null,
+                authorCountryId: country.id,
+                authorUserId: userId ?? null,
+            },
+            select: {
+                id: true,
+                body: true,
+                parentPostId: true,
+                isEdited: true,
+                isDeleted: true,
+                deletedAt: true,
+                editedAt: true,
+                createdAt: true,
+                updatedAt: true,
+                authorUser: { select: { id: true, name: true, image: true } },
+                authorCountry: {
+                    select: { id: true, name: true, slug: true, code: true, colorHex: true },
+                },
+            },
+        });
+
+        await prisma.discussionThread.update({
+            where: { id: thread.id },
+            data: { lastPostAt: new Date() },
+        });
+
+        return NextResponse.json({ post }, { status: 201 });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to create discussion post", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/motions/[motionId]/second/route.ts
+++ b/src/app/api/motions/[motionId]/second/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const secondMotionSchema = z.object({
+    note: z.string().optional(),
+});
+
+type MotionContext = {
+    seconds?: string[];
+    [key: string]: unknown;
+};
+
+function normaliseContext(context: unknown): MotionContext {
+    if (!context || typeof context !== "object") {
+        return {};
+    }
+
+    const parsed = context as MotionContext;
+    const seconds = Array.isArray(parsed.seconds)
+        ? parsed.seconds.filter((value): value is string => typeof value === "string")
+        : [];
+
+    return { ...parsed, seconds };
+}
+
+export async function POST(
+    req: Request,
+    { params }: { params: Promise<{ motionId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { country } = await requireAuthContext();
+        const parsed = secondMotionSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const motion = await prisma.modMotion.findUnique({
+            where: { id: awaitedParams.motionId },
+            select: { id: true, status: true, context: true },
+        });
+
+        if (!motion) {
+            throw new ApiError(404, "Motion not found");
+        }
+
+        if (motion.status !== "PROPOSED" && motion.status !== "VOTING") {
+            throw new ApiError(409, "Motion cannot be seconded in its current state");
+        }
+
+        const context = normaliseContext(motion.context);
+        const seconds = new Set(context.seconds ?? []);
+
+        if (seconds.has(country.id)) {
+            throw new ApiError(409, "Country has already seconded this motion");
+        }
+
+        seconds.add(country.id);
+        const now = new Date();
+
+        const updatedMotion = await prisma.modMotion.update({
+            where: { id: motion.id },
+            data: {
+                status: motion.status === "PROPOSED" ? "VOTING" : motion.status,
+                openedAt: motion.status === "PROPOSED" ? now : undefined,
+                context: {
+                    ...context,
+                    seconds: Array.from(seconds),
+                },
+            },
+        });
+
+        return NextResponse.json({ motion: updatedMotion });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to second motion", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/motions/[motionId]/vote/route.ts
+++ b/src/app/api/motions/[motionId]/vote/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const voteSchema = z.object({
+    choice: z.enum(["APPROVE", "REJECT", "ABSTAIN"]),
+    comment: z.string().optional(),
+});
+
+interface VoteTally {
+    approve: number;
+    reject: number;
+    abstain: number;
+}
+
+function countVotes(votes: { choice: "APPROVE" | "REJECT" | "ABSTAIN" }[]): VoteTally {
+    const tally: VoteTally = { approve: 0, reject: 0, abstain: 0 };
+    for (const vote of votes) {
+        if (vote.choice === "APPROVE") tally.approve += 1;
+        else if (vote.choice === "REJECT") tally.reject += 1;
+        else tally.abstain += 1;
+    }
+    return tally;
+}
+
+export async function POST(
+    req: Request,
+    { params }: { params: Promise<{ motionId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { userId, country, quorum } = await requireAuthContext();
+        const parsed = voteSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const motion = await prisma.modMotion.findUnique({
+            where: { id: awaitedParams.motionId },
+            select: { id: true, status: true },
+        });
+
+        if (!motion) {
+            throw new ApiError(404, "Motion not found");
+        }
+
+        if (motion.status !== "VOTING") {
+            throw new ApiError(409, "Motion is not open for voting");
+        }
+
+        const result = await prisma.$transaction(async (tx) => {
+            await tx.modVote.upsert({
+                where: {
+                    motionId_countryId: {
+                        motionId: motion.id,
+                        countryId: country.id,
+                    },
+                },
+                update: {
+                    choice: parsed.data.choice,
+                    comment: parsed.data.comment ?? null,
+                },
+                create: {
+                    motionId: motion.id,
+                    countryId: country.id,
+                    userId: userId ?? null,
+                    choice: parsed.data.choice,
+                    comment: parsed.data.comment ?? null,
+                },
+            });
+
+            const votes = await tx.modVote.findMany({
+                where: { motionId: motion.id },
+                select: { choice: true },
+            });
+
+            const tally = countVotes(votes);
+            let updatedMotion = await tx.modMotion.findUnique({ where: { id: motion.id } });
+            if (!updatedMotion) {
+                throw new ApiError(404, "Motion not found after voting");
+            }
+
+            if (updatedMotion.status === "VOTING" && votes.length >= quorum.required) {
+                const passes = tally.approve > tally.reject;
+                const newStatus = passes ? "PASSED" : "FAILED";
+                const note = passes
+                    ? `Motion passed ${tally.approve}-${tally.reject}-${tally.abstain}`
+                    : `Motion failed ${tally.approve}-${tally.reject}-${tally.abstain}`;
+
+                updatedMotion = await tx.modMotion.update({
+                    where: { id: motion.id },
+                    data: {
+                        status: newStatus,
+                        closedAt: new Date(),
+                        resolvedAt: new Date(),
+                        resolutionNote: note,
+                    },
+                });
+            }
+
+            return { tally, motion: updatedMotion, totalVotes: votes.length };
+        });
+
+        return NextResponse.json({
+            motion: result.motion,
+            tally: result.tally,
+            totalVotes: result.totalVotes,
+            quorum: quorum.required,
+        });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to record motion vote", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/motions/[motionId]/withdraw/route.ts
+++ b/src/app/api/motions/[motionId]/withdraw/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const withdrawSchema = z.object({
+    note: z.string().optional(),
+});
+
+const FINAL_STATUSES = new Set([
+    "PASSED",
+    "FAILED",
+    "WITHDRAWN",
+    "EXECUTED",
+]);
+
+export async function POST(
+    req: Request,
+    { params }: { params: Promise<{ motionId: string }> },
+) {
+    try {
+        const awaitedParams = await params;
+        const { country } = await requireAuthContext();
+        const parsed = withdrawSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const motion = await prisma.modMotion.findUnique({
+            where: { id: awaitedParams.motionId },
+            select: { id: true, status: true, createdByCountryId: true },
+        });
+
+        if (!motion) {
+            throw new ApiError(404, "Motion not found");
+        }
+
+        if (motion.createdByCountryId !== country.id) {
+            throw new ApiError(403, "Only the proposing country may withdraw the motion");
+        }
+
+        if (FINAL_STATUSES.has(motion.status)) {
+            throw new ApiError(409, "Motion is already resolved");
+        }
+
+        const updatedMotion = await prisma.modMotion.update({
+            where: { id: motion.id },
+            data: {
+                status: "WITHDRAWN",
+                closedAt: new Date(),
+                resolvedAt: new Date(),
+                resolutionNote: parsed.data.note ?? null,
+            },
+        });
+
+        return NextResponse.json({ motion: updatedMotion });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to withdraw motion", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/motions/route.ts
+++ b/src/app/api/motions/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/prisma";
+import { ApiError, requireAuthContext } from "@/utils/api/guards";
+import z from "zod";
+
+const createMotionSchema = z.object({
+    type: z.enum([
+        "LOCK_THREAD",
+        "UNLOCK_THREAD",
+        "PIN_THREAD",
+        "UNPIN_THREAD",
+        "ARCHIVE_THREAD",
+        "REMOVE_POST",
+        "RESTORE_POST",
+        "ISSUE_SANCTION",
+        "LIFT_SANCTION",
+    ]),
+    title: z.string().min(1, "Title is required"),
+    description: z.string().optional(),
+    rationale: z.string().optional(),
+    context: z.unknown().optional(),
+    targetThreadId: z.string().optional(),
+    targetPostId: z.string().optional(),
+    targetCountryId: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+    try {
+        const { userId, country } = await requireAuthContext();
+        const parsed = createMotionSchema.safeParse(await req.json());
+
+        if (!parsed.success) {
+            return NextResponse.json({ errors: parsed.error.flatten() }, { status: 400 });
+        }
+
+        const { targetThreadId, targetPostId, targetCountryId } = parsed.data;
+
+        if (targetThreadId) {
+            const thread = await prisma.discussionThread.findUnique({
+                where: { id: targetThreadId },
+                select: { id: true },
+            });
+
+            if (!thread) {
+                throw new ApiError(404, "Target thread not found");
+            }
+        }
+
+        if (targetPostId) {
+            const post = await prisma.discussionPost.findUnique({
+                where: { id: targetPostId },
+                select: { id: true, threadId: true },
+            });
+
+            if (!post) {
+                throw new ApiError(404, "Target post not found");
+            }
+
+            if (targetThreadId && post.threadId !== targetThreadId) {
+                throw new ApiError(400, "Target post must belong to the specified thread");
+            }
+        }
+
+        if (targetCountryId) {
+            const targetCountry = await prisma.country.findUnique({
+                where: { id: targetCountryId },
+                select: { id: true },
+            });
+
+            if (!targetCountry) {
+                throw new ApiError(404, "Target country not found");
+            }
+        }
+
+        const motion = await prisma.modMotion.create({
+            data: {
+                type: parsed.data.type,
+                status: "PROPOSED",
+                title: parsed.data.title,
+                description: parsed.data.description ?? null,
+                rationale: parsed.data.rationale ?? null,
+                context: parsed.data.context ?? null,
+                targetThreadId: parsed.data.targetThreadId ?? null,
+                targetPostId: parsed.data.targetPostId ?? null,
+                targetCountryId: parsed.data.targetCountryId ?? null,
+                createdByCountryId: country.id,
+                createdByUserId: userId ?? null,
+                submittedAt: new Date(),
+            },
+        });
+
+        return NextResponse.json({ motion }, { status: 201 });
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return NextResponse.json({ error: error.message }, { status: error.status });
+        }
+
+        console.error("Failed to create motion", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/utils/api/guards.ts
+++ b/src/utils/api/guards.ts
@@ -1,0 +1,132 @@
+import type { Session } from "next-auth";
+import { auth } from "@/auth";
+import { prisma } from "@/prisma";
+
+export class ApiError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+        super(message);
+        this.name = "ApiError";
+        this.status = status;
+    }
+}
+
+export interface CountryAuthContext {
+    id: string;
+    name: string;
+    slug: string;
+    hasVeto: boolean;
+    isActive: boolean;
+}
+
+export interface QuorumInfo {
+    totalActiveCountries: number;
+    required: number;
+}
+
+export interface AuthContext {
+    session: Session;
+    userId?: string;
+    country: CountryAuthContext;
+    quorum: QuorumInfo;
+}
+
+const MINIMUM_COUNTRIES_FOR_QUORUM = 3;
+
+async function fetchQuorumInfo(): Promise<QuorumInfo> {
+    const totalActiveCountries = await prisma.country.count({ where: { isActive: true } });
+    const required = Math.max(MINIMUM_COUNTRIES_FOR_QUORUM, Math.ceil(totalActiveCountries * 0.5));
+
+    if (totalActiveCountries < required) {
+        throw new ApiError(
+            409,
+            `Quorum not met: ${totalActiveCountries} of ${required} active countries available`,
+        );
+    }
+
+    return { totalActiveCountries, required };
+}
+
+async function ensureCountryNotSanctioned(countryId: string) {
+    const now = new Date();
+    const sanction = await prisma.sanction.findFirst({
+        where: {
+            targetCountryId: countryId,
+            isActive: true,
+            rescindedAt: null,
+            AND: [
+                {
+                    OR: [
+                        { effectiveAt: null },
+                        { effectiveAt: { lte: now } },
+                    ],
+                },
+                {
+                    OR: [
+                        { expiresAt: null },
+                        { expiresAt: { gt: now } },
+                    ],
+                },
+            ],
+        },
+        select: { id: true, title: true, type: true },
+    });
+
+    if (sanction) {
+        throw new ApiError(403, `Country under active sanction: ${sanction.title}`);
+    }
+}
+
+async function fetchCountry(countryId: string): Promise<CountryAuthContext> {
+    const country = await prisma.country.findUnique({
+        where: { id: countryId },
+        select: {
+            id: true,
+            name: true,
+            slug: true,
+            hasVeto: true,
+            isActive: true,
+        },
+    });
+
+    if (!country) {
+        throw new ApiError(403, "Assigned country not found");
+    }
+
+    if (!country.isActive) {
+        throw new ApiError(403, "Country is inactive");
+    }
+
+    return country;
+}
+
+export async function requireAuthContext(options?: { requireChair?: boolean }): Promise<AuthContext> {
+    const session = await auth();
+    if (!session) {
+        throw new ApiError(401, "Unauthorized");
+    }
+
+    const countryId = session.user?.countryId ?? undefined;
+    if (!countryId) {
+        throw new ApiError(403, "No country assigned");
+    }
+
+    const country = await fetchCountry(countryId);
+    await ensureCountryNotSanctioned(country.id);
+    const quorum = await fetchQuorumInfo();
+
+    if (options?.requireChair) {
+        const isChair = country.hasVeto || country.slug === "chair";
+        if (!isChair) {
+            throw new ApiError(403, "Chair privileges required");
+        }
+    }
+
+    return {
+        session,
+        userId: session.user?.id ?? undefined,
+        country,
+        quorum,
+    };
+}


### PR DESCRIPTION
## Summary
- add shared auth, sanction, and quorum guard helpers for API routes
- implement amendment discussion bootstrap endpoint and discussion post CRUD APIs
- add motion create/second/vote/withdraw routes and chair rule/emergency handlers with logging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c841d4914c832ca92a9223fadb02c5