### PR TITLE
Refactor WebSocket API to Node runtime

### DIFF
--- a/src/app/api/socket/state.ts
+++ b/src/app/api/socket/state.ts
@@ -1,4 +1,6 @@
-export type ServerWebSocket = WebSocket & {
+import type { WebSocket as NodeWebSocket } from 'next/dist/compiled/ws';
+
+export type ServerWebSocket = (WebSocket | NodeWebSocket) & {
   accept?: () => void;
 };
 

--- a/src/pages/api/socket.ts
+++ b/src/pages/api/socket.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest } from 'next';
+import type { NextApiResponse } from 'next';
+import type { Server as HttpServer } from 'http';
+import type { Socket } from 'net';
+import { WebSocketServer } from 'next/dist/compiled/ws';
+
+import { DEFAULT_ROOM_ID, handlePresenceConnection } from '@/app/api/socket/presenceServer';
+
+type NextApiResponseWithSocket = NextApiResponse & {
+  socket: NextApiResponse['socket'] & {
+    server: HttpServer & {
+      wss?: WebSocketServer;
+    };
+  };
+};
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponseWithSocket) {
+  if (req.headers.upgrade?.toLowerCase() !== 'websocket') {
+    res.status(426).send('Expected WebSocket upgrade.');
+    return;
+  }
+
+  const server = res.socket.server;
+
+  if (!server.wss) {
+    const wss = new WebSocketServer({ noServer: true });
+    server.wss = wss;
+
+    wss.on('connection', (websocket, request) => {
+      const url = new URL(request.url ?? '', `http://${request.headers.host ?? 'localhost'}`);
+      const roomId = url.searchParams.get('room') ?? DEFAULT_ROOM_ID;
+      handlePresenceConnection(websocket, roomId);
+    });
+  }
+
+  const wss = server.wss;
+
+  wss.handleUpgrade(req, req.socket as Socket, Buffer.alloc(0), (websocket) => {
+    wss.emit('connection', websocket, req);
+  });
+
+  res.end();
+}

--- a/types/next-ws.d.ts
+++ b/types/next-ws.d.ts
@@ -1,0 +1,41 @@
+declare module 'next/dist/compiled/ws' {
+  import type { EventEmitter } from 'events';
+  import type { IncomingMessage } from 'http';
+  import type { Socket } from 'net';
+
+  export type RawData = string | Buffer | ArrayBuffer | Buffer[];
+
+  export class WebSocket extends EventEmitter {
+    readyState: number;
+    send(data: string | Buffer | ArrayBufferView): void;
+    close(code?: number, reason?: string): void;
+    addEventListener?(
+      event: 'message',
+      listener: (event: { data: string | ArrayBuffer | Buffer }) => void,
+    ): void;
+    addEventListener?(event: 'close' | 'error', listener: (...args: unknown[]) => void): void;
+    on(event: 'message', listener: (data: RawData) => void): this;
+    on(event: 'close', listener: (...args: unknown[]) => void): this;
+    on(event: 'error', listener: (...args: unknown[]) => void): this;
+  }
+
+  export class WebSocketServer extends EventEmitter {
+    constructor(options?: { noServer?: boolean });
+    handleUpgrade(
+      request: IncomingMessage,
+      socket: Socket,
+      head: Buffer,
+      callback: (socket: WebSocket) => void,
+    ): void;
+    emit(event: 'connection', socket: WebSocket, request: IncomingMessage): boolean;
+    on(event: 'connection', listener: (socket: WebSocket, request: IncomingMessage) => void): this;
+  }
+
+  export const CONNECTING: number;
+  export const OPEN: number;
+  export const CLOSING: number;
+  export const CLOSED: number;
+
+  export { WebSocketServer as Server, WebSocket };
+  export default WebSocket;
+}


### PR DESCRIPTION
## Summary
- replace the edge route with a Node-based API route that upgrades connections with Next's compiled `ws` server
- refactor the presence server logic to work with Node sockets while preserving heartbeat and queue handling
- add typings for the bundled `ws` package and adjust shared state types to support both browser and Node sockets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84a5fba80832c87d10e6a69ace787