### PR TITLE
Update WebSocket message handler typing

### DIFF
--- a/src/app/api/socket/presenceServer.ts
+++ b/src/app/api/socket/presenceServer.ts
@@ -143,7 +143,7 @@ function attachEventHandler(
 function attachMessageHandler(socket: ServerWebSocket, handler: (raw: string) => void) {
   const candidate = socket as unknown as {
     addEventListener?: (type: string, listener: (event: MessageEvent) => void) => void;
-    on?: (type: string, listener: (...args: unknown[]) => void) => void;
+    on?: (type: string, listener: (data: RawData, isBinary?: boolean) => void) => void;
   };
 
   if (typeof candidate.addEventListener === 'function') {


### PR DESCRIPTION
## Summary
- narrow the `candidate.on` listener typing in `attachMessageHandler` so WebSocket payloads are provided to the listener

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84eaa4740832cb50deb8637e09d2a