### PR TITLE
Support tenant-aware base URLs

### DIFF
--- a/src/app/amendments/[slug]/discussion/page.tsx
+++ b/src/app/amendments/[slug]/discussion/page.tsx
@@ -5,8 +5,9 @@ import { epunda } from "@/app/fonts";
 // import { auth } from "@/auth";
 import { prisma } from "@/prisma";
 import { CouncilSessionUI } from "@/components/CouncilSession";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export async function generateMetadata({
   params,

--- a/src/app/amendments/[slug]/page.tsx
+++ b/src/app/amendments/[slug]/page.tsx
@@ -10,10 +10,11 @@ import StatusBanner from "@/components/Amendment/StatusBanner";
 import VoteMeter from "@/components/Amendment/VoteMeter";
 import VoteSummary from "@/components/Amendment/VoteSummary";
 import { auth } from "@/auth";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
 export const dynamic = "force-dynamic";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
     const { slug } = await params;

--- a/src/app/amendments/new/page.tsx
+++ b/src/app/amendments/new/page.tsx
@@ -6,8 +6,9 @@ import { auth } from "@/auth";
 import type { Metadata } from "next";
 import NewAmendmentComposer from "@/components/NewAmendmentComposer";
 import { createAmendmentAction } from "@/utils/api/amendments";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
   title: "Propose Amendment • League",

--- a/src/app/amendments/page.tsx
+++ b/src/app/amendments/page.tsx
@@ -6,10 +6,11 @@ import { redirect } from "next/navigation";
 
 import type { Metadata } from "next";
 import AmendmentsClient from "../../components/AmendmentsClient";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
 export const dynamic = "force-dynamic";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
     title: "Amendments • League",

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { epunda } from "@/app/fonts";
 import type { Metadata } from "next";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
   title: "FAQ • League",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,8 +9,12 @@ import Header from "../components/Header";
 // Use a serif font for an early-1900s feel
 import { epunda } from "@/app/fonts"; // <-- local font helper
 import Footer from "../components/Footer";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
+
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
   title: {
     default: "League Treaty Portal",
     template: "%s • League Treaty Portal",
@@ -29,7 +33,7 @@ export const metadata: Metadata = {
     title: "League Treaty Portal",
     description:
       "The Treaty of the League of Free and Independent Nations, established in 1900 as a collective defense pact.",
-    url: "https://example.com",
+    url: baseUrl,
     siteName: "League Treaty Portal",
     locale: "en_US",
     type: "website",

--- a/src/app/members/[slugOrCode]/page.tsx
+++ b/src/app/members/[slugOrCode]/page.tsx
@@ -4,8 +4,9 @@ import { epunda } from "@/app/fonts";
 import { getCountry } from "@/utils/country";
 import Image from "next/image";
 import type { Metadata } from "next";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export async function generateMetadata({ params }: { params: Promise<{ slugOrCode: string }> }): Promise<Metadata> {
     const awaitedParams = await params;

--- a/src/app/members/me/page.tsx
+++ b/src/app/members/me/page.tsx
@@ -6,8 +6,9 @@ import Image from "next/image";
 import { auth } from "@/auth";
 import { getCountry } from "@/utils/country";
 import type { Metadata } from "next";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
     title: "My Country • League",

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -4,8 +4,9 @@ import { prisma } from "@/prisma";
 import { epunda } from "@/app/fonts";
 import { auth } from "@/auth";
 import type { Metadata } from "next";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
     title: "Countries • League",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,11 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { epunda } from "@/app/fonts";
 import { prisma } from "@/prisma";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
 export const dynamic = "force-dynamic";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
   title: "Home • League",

--- a/src/app/treaty/page.tsx
+++ b/src/app/treaty/page.tsx
@@ -2,11 +2,12 @@ import { prisma } from "@/prisma";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import TreatyClient from "./TreatyClient";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
     title: "Treaty • League",

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,7 +1,8 @@
 import { epunda } from "@/app/fonts";
 import type { Metadata } from "next";
+import { getPublicBaseUrl } from "@/utils/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = getPublicBaseUrl();
 
 export const metadata: Metadata = {
   title: "Our Work • League",

--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -1,14 +1,10 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { getServerBaseUrl } from "@/utils/baseUrl";
 
 export async function getBaseUrl() {
-    // Prefer NEXTAUTH_URL (used by Auth.js), then public base, then dev default
-    return (
-        process.env.NEXTAUTH_URL ||
-        process.env.NEXT_PUBLIC_BASE_URL ||
-        "http://localhost:3000"
-    );
+    return getServerBaseUrl();
 }
 
 export async function apiPost<T>(

--- a/src/utils/baseUrl.ts
+++ b/src/utils/baseUrl.ts
@@ -1,0 +1,103 @@
+const DEFAULT_BASE_URL = "http://localhost:3000";
+
+function trimTrailingSlash(url: string): string {
+    return url.replace(/\/+$/, "");
+}
+
+function trimSlashes(value: string): string {
+    return value.replace(/^\/+|\/+$/g, "");
+}
+
+function readTenantSlug(): string | null {
+    const raw =
+        process.env.NEXT_PUBLIC_TENANT_SLUG ??
+        process.env.NEXT_PUBLIC_TENANT ??
+        process.env.TENANT_SLUG ??
+        process.env.TENANT ??
+        "";
+
+    const normalized = trimSlashes(raw.trim());
+    return normalized.length > 0 ? normalized : null;
+}
+
+function applyTenantToBase(rawBaseUrl: string, tenant: string | null): string {
+    let candidate = rawBaseUrl.trim();
+    if (!candidate) {
+        candidate = DEFAULT_BASE_URL;
+    }
+
+    try {
+        const parsed = new URL(candidate);
+        const tenantSlug = tenant;
+        let pathname = trimTrailingSlash(parsed.pathname);
+
+        if (tenantSlug) {
+            const tenantLower = tenantSlug.toLowerCase();
+            const lowerHost = parsed.hostname.toLowerCase();
+            const tenantPrefix = `${tenantLower}.`;
+            if (lowerHost.startsWith(tenantPrefix)) {
+                parsed.hostname = parsed.hostname.slice(tenantSlug.length + 1);
+            }
+
+            const tenantPath = `/${tenantSlug}`;
+            const pathnameLower = pathname.toLowerCase();
+            if (pathnameLower === tenantPath.toLowerCase()) {
+                pathname = "";
+            } else if (pathnameLower.endsWith(tenantPath.toLowerCase())) {
+                pathname = pathname.slice(0, -tenantPath.length);
+            }
+        }
+
+        const origin = `${parsed.protocol}//${parsed.host}`;
+        candidate = pathname && pathname !== "/" ? `${origin}${pathname}` : origin;
+    } catch {
+        candidate = trimTrailingSlash(candidate);
+    }
+
+    candidate = trimTrailingSlash(candidate);
+    if (!candidate) {
+        candidate = DEFAULT_BASE_URL;
+    }
+
+    if (tenant) {
+        const tenantPath = `/${tenant}`;
+        if (candidate.toLowerCase().endsWith(tenantPath.toLowerCase())) {
+            return candidate;
+        }
+        return `${candidate}${tenantPath}`;
+    }
+
+    return candidate;
+}
+
+export function getPublicBaseUrl(): string {
+    const tenant = readTenantSlug();
+    const base =
+        process.env.NEXT_PUBLIC_BASE_URL?.trim() ||
+        process.env.NEXTAUTH_URL?.trim() ||
+        DEFAULT_BASE_URL;
+
+    return applyTenantToBase(base, tenant);
+}
+
+export function getServerBaseUrl(): string {
+    const tenant = readTenantSlug();
+    const base =
+        process.env.NEXTAUTH_URL?.trim() ||
+        process.env.NEXT_PUBLIC_BASE_URL?.trim() ||
+        DEFAULT_BASE_URL;
+
+    return applyTenantToBase(base, tenant);
+}
+
+export function buildTenantUrl(path: string): string {
+    const base = getPublicBaseUrl();
+    if (!path) {
+        return base;
+    }
+    return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function getTenantSlug(): string | null {
+    return readTenantSlug();
+}


### PR DESCRIPTION
## Summary
- add a tenant-aware base URL helper that normalizes environment variables and converts slug subdomains into path prefixes
- update the API client and metadata generators to rely on the helper so canonical links resolve to baseurl/tenant
- set the root layout metadata base and refresh canonical/OG URLs across key pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f62083bca8832c9389628a4ede8c3e